### PR TITLE
퀴즈 시작페이지 GET 일경우 &  POST 일경우 test.py, views.py, quiz_start.html 작성 및 구현

### DIFF
--- a/make_quiz/views.py
+++ b/make_quiz/views.py
@@ -8,10 +8,13 @@ from .models import QuizExample, QuizQuestion
 # Create your views here.
 # todo: 퀴즈생성 함수
 def create_quiz(user, title, private):
-    if private:  # True이면 비공개 설정
-        return Quiz.objects.create(author=user, title=title, private=private)
-    else:  # False이면 공개설정 default=False
-        return Quiz.objects.create(author=user, title=title)
+    quiz = Quiz.objects.create(author=user, title=title)
+
+    if private:  # True(비공개설정)
+        quiz.private = True
+        quiz.save()
+
+    return quiz
 
 
 # todo: 문제생성 함수
@@ -21,41 +24,36 @@ def create_question(quiz, question_no, content):
 
 # todo: 보기생성 함수
 def create_example(question, data):
-    # print(data["example1"]["no"])
-    # print(data["example1"]["content"])
-
     QuizExample.objects.bulk_create(
         [
             QuizExample(
                 question=question,
                 no=data["example1"]["no"],
                 content=data["example1"]["content"],
-                answer=False,
             ),
             QuizExample(
                 question=question,
                 no=data["example2"]["no"],
                 content=data["example2"]["content"],
-                answer=False,
             ),
             QuizExample(
                 question=question,
                 no=data["example3"]["no"],
                 content=data["example3"]["content"],
-                answer=False,
             ),
             QuizExample(
                 question=question,
                 no=data["example4"]["no"],
                 content=data["example4"]["content"],
-                answer=False,
             ),
         ]
     )
 
-    quiz_answer = QuizExample.objects.get(question=question, no=data["answer"]["no"])
-    quiz_answer.answer = True
-    quiz_answer.save()
+    quizexample_answer = QuizExample.objects.get(
+        question=question, no=data["answer"]["no"]
+    )
+    quizexample_answer.answer = True
+    quizexample_answer.save()
 
 
 def create_my_quiz(request):

--- a/solve_quiz/templates/solve_quiz/quiz.html
+++ b/solve_quiz/templates/solve_quiz/quiz.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>문제 풀기 페이지</title>
 </head>
 <body>
-
+    야호
 </body>
 </html>

--- a/solve_quiz/templates/solve_quiz/quiz_start.html
+++ b/solve_quiz/templates/solve_quiz/quiz_start.html
@@ -7,5 +7,6 @@
 <body>
     <div id="quiz_title">{{ quiz.title }}</div>
     <div id="quiz_author">{{ quiz.author }}</div>
+    <div id="random_saying">{{ saying }}</div>
 </body>
 </html>

--- a/solve_quiz/templates/solve_quiz/quiz_start.html
+++ b/solve_quiz/templates/solve_quiz/quiz_start.html
@@ -5,8 +5,21 @@
     <title>문제 시작 페이지</title>
 </head>
 <body>
-    <div id="quiz_title">{{ quiz.title }}</div>
-    <div id="quiz_author">{{ quiz.author }}</div>
-    <div id="random_saying">{{ saying }}</div>
+<form name="frm" action="" method="post">
+    {% csrf_token %}
+    <div id="quiz-title">{{ quiz.title }}</div>
+    <div id="quiz-author">{{ quiz.author }}</div>
+    <div id="random-saying">{{ saying }}</div>
+
+    <input type="text" name="tester-name" placeholder="응시자 이름을 입력해주세요">
+    <input type="date" id="test-date" name="test-date" placeholder="응시날짜를 입력해주세요">
+    <input type="text" id="saying" name="follow-saying" placeholder="따라 써주세요">
+    <input type="hidden" name="saying" value="{{ saying }}">
+
+
+    <div class="footer">
+        <input type="submit" class="btn btn-light" id="start-btn" value="시작하기"/>
+    </div>
+</form>
 </body>
 </html>

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -93,8 +93,8 @@ class StartQuizTestView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual("문제 시작 페이지", soup.title.text)
 
-    # 2. 시작하기 버튼 누르면 필적확인란이 같을경우 응시자와 오늘날짜가 session에 들어가는지 확인
-    def test_quiz_start_page_post_same_saying_tester_and_today_in_session_check(self):
+    # 2. 시작하기 버튼 누르면 필적확인란이 같을경우 info(응시자와 오늘날짜)가 session에 들어가는지 확인
+    def test_quiz_start_page_post_same_saying_info_in_session_check(self):
         # Given
         response = self.client.get(self.quiz_001.get_absolute_url())
         saying = response.context["saying"]

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -45,7 +45,7 @@ class SolveQuizTestView(TestCase):
 
     # TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(GET)
     # 1. 로그인 확인 여부없이 quiz_start 페이지로 이동 확인
-    def test_enter_quiz_start(self):
+    def test_enter_quiz_start_page(self):
         # Given
         response = self.client.get(self.quiz_001.get_absolute_url())
 
@@ -58,7 +58,7 @@ class SolveQuizTestView(TestCase):
         self.assertEqual("문제 시작 페이지", soup.title.text)
 
     # 2. quiz의 테스트 제목, 출제자 확인
-    def test_quiz_start_get_title_and_user_check(self):
+    def test_quiz_start_page_get_title_and_user_check(self):
         # Given
         response = self.client.get(self.quiz_001.get_absolute_url())
 
@@ -78,7 +78,7 @@ class SolveQuizTestView(TestCase):
         self.assertEqual(self.quiz_001.author.username, quiz_author.text)
 
     # 3. 필적확인란 랜덤 명언 값 존재하는지 확인하기
-    def test_quiz_start_get_random_saying_check(self):
+    def test_quiz_start_page_get_random_saying_check(self):
         # Given
         response = self.client.get(self.quiz_001.get_absolute_url())
 

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
@@ -88,10 +90,32 @@ class SolveQuizTestView(TestCase):
         # Then
         self.assertIn(saying.text, sayings)
 
-    # 4. 시작하기 버튼
-    #   시작하기 버튼 누르면 성명, 응시일자 저장되는지 확인
-    #   시작하기 버튼 누르면 필적확인란 값 일치하는지 확인
-    #   시작하기 버튼 누르면 quiz_solve 페이지로 이동 확인
+    # TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(POST)
+    # 1. 시작하기 버튼 누르면 필적확인란 값이 다를경우 재로드 확인
+    def test_quiz_start_page_post_diffrent_saying_check(self):
+        # Given
+        response = self.client.get(self.quiz_001.get_absolute_url())
+        saying = response.context["saying"]
+        data = {
+            "saying": saying,
+            "follow-saying": "제시된 필적확인란과 다르게 적음",
+        }
+
+        # When
+        self.client.post(self.quiz_001.get_absolute_url(), data)
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        # Then
+        """
+        필적확인란 값이 다른지 확인
+        quiz_start.html 재로드
+        """
+        self.assertNotEqual(data["saying"], data["follow-saying"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual("문제 시작 페이지", soup.title.text)
+
+    # 2. 시작하기 버튼 누르면 필적확인란이 같을경우 응시자와 오늘날짜가 session에 들어가는지 확인
+    # 3. 시작하기 버튼 누르면 필적확인란이 같을경우 quiz_solve 페이지로 이동 확인
 
     # TODO: 문제풀기 페이지로 이동했을경우 quiz_solve 페이지 확인
     # 1. quiz의 테스트 제목, 출제자 확인

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -4,6 +4,7 @@ from django.test import Client, TestCase
 
 from make_quiz.models import QuizExample, QuizQuestion
 from my_quiz.models import Quiz
+from solve_quiz.views import random_saying
 
 
 # Create your tests here.
@@ -72,6 +73,17 @@ class SolveQuizTestView(TestCase):
         )  # quiz의 문제 출제자 확인
 
     # 3. 필적확인란 랜덤 명언 값 존재하는지 확인하기
+    def test_quiz_start_random_saying_check(self):
+        # Given
+        response = self.client.get(self.quiz_001.get_absolute_url())
+
+        # When
+        soup = BeautifulSoup(response.content, "html.parser")
+        saying = soup.find("div", id="random_saying")
+
+        # Then
+        self.assertIn(saying.text, random_saying())
+
     # 4. 시작하기 버튼
     #   시작하기 버튼 누르면 성명, 응시일자 저장되는지 확인
     #   시작하기 버튼 누르면 필적확인란 값 일치하는지 확인

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -9,7 +9,7 @@ from my_quiz.models import Quiz
 
 
 # Create your tests here.
-class SolveQuizTestView(TestCase):
+class StartQuizTestView(TestCase):
 
     # TODO: SetUp
     # 퀴즈 하나 만들기

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -87,8 +87,8 @@ class SolveQuizTestView(TestCase):
         saying = soup.find("div", id="random-saying")
 
         # Then
-        '''response로 보낸 명언과 html의 명언 일치확인'''
-        self.assertEqual(response.context['saying'], saying.text)
+        """response로 보낸 명언과 html의 명언 일치확인"""
+        self.assertEqual(response.context["saying"], saying.text)
 
     # TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(POST)
     # 1. 시작하기 버튼 누르면 필적확인란 값이 다를경우 재로드 확인

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -43,7 +43,7 @@ class SolveQuizTestView(TestCase):
             self.quizexample_answer.answer = True
             self.quizexample_answer.save()
 
-    # TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인
+    # TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(GET)
     # 1. 로그인 확인 여부없이 quiz_start 페이지로 이동 확인
     def test_enter_quiz_start(self):
         # Given

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -22,27 +22,6 @@ class StartQuizTestView(TestCase):
         # 퀴즈 1개
         self.quiz_001 = Quiz.objects.create(author=self.user, title="나를 맞춰봐!")
 
-        # 문제 10개
-        for question_num in range(1, 11):
-            self.quiz_001_question = QuizQuestion.objects.create(
-                quiz=self.quiz_001, no=question_num, content=f"문제{question_num}번 내용"
-            )
-
-            # 한 문제당 보기 4개
-            for example_num in range(1, 5):
-                QuizExample.objects.create(
-                    question=self.quiz_001_question,
-                    no=example_num,
-                    content=f"문제{question_num}-보기{example_num}번 내용",
-                )
-
-            # 답(무조건 1번)
-            self.quizexample_answer = QuizExample.objects.get(
-                question=self.quiz_001_question, no=1
-            )
-            self.quizexample_answer.answer = True
-            self.quizexample_answer.save()
-
     # TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(GET)
     # 1. 로그인 확인 여부없이 quiz_start 페이지로 이동 확인
     def test_enter_quiz_start_page(self):

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -58,20 +58,24 @@ class SolveQuizTestView(TestCase):
         self.assertEqual("문제 시작 페이지", soup.title.text)
 
     # 2. quiz의 테스트 제목, 출제자 확인
-    def test_quiz_start_title_and_user_check(self):
+    def test_quiz_start_get_title_and_user_check(self):
         # Given
         response = self.client.get(self.quiz_001.get_absolute_url())
 
         # When
         soup = BeautifulSoup(response.content, "html.parser")
-        quiz_title = soup.find("div", id="quiz_title")
-        quiz_author = soup.find("div", id="quiz_author")
+        quiz_title = soup.find("div", id="quiz-title")
+        quiz_author = soup.find("div", id="quiz-author")
 
         # Then
-        self.assertIn(self.quiz_001.title, quiz_title.text)  # quiz의 문제 제목 확인
-        self.assertEqual(
-            self.quiz_001.author.username, quiz_author.text
-        )  # quiz의 문제 출제자 확인
+        """
+        response시 pk에 맞는 quiz object 인지 확인
+        quiz의 문제 제목 확인
+        quiz의 문제 출제자 확인
+        """
+        self.assertEqual(response.context["quiz"], self.quiz_001)
+        self.assertEqual(self.quiz_001.title, quiz_title.text)
+        self.assertEqual(self.quiz_001.author.username, quiz_author.text)
 
     # 3. 필적확인란 랜덤 명언 값 존재하는지 확인하기
     def test_quiz_start_random_saying_check(self):

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -142,6 +142,23 @@ class SolveQuizTestView(TestCase):
         self.assertEqual(test_date, data["test-date"].strftime("%Y-%m-%d"))
 
     # 3. 시작하기 버튼 누르면 필적확인란이 같을경우 quiz_solve 페이지로 이동 확인
+    def test_quiz_start_page_post_same_saying_enter_quiz_page(self):
+        # Given
+        get_response = self.client.get(self.quiz_001.get_absolute_url())
+        saying = get_response.context["saying"]
+
+        data = {
+            "tester-name": self.user.username,
+            "test-date": date.today(),
+            "follow-saying": saying,
+            "saying": saying,
+        }
+
+        # When
+        post_response = self.client.post(self.quiz_001.get_absolute_url(), data)
+
+        # Then
+        self.assertEqual(post_response.url, "/qui-es/1/solving/")
 
     # TODO: 문제풀기 페이지로 이동했을경우 quiz_solve 페이지 확인
     # 1. quiz의 테스트 제목, 출제자 확인

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -115,6 +115,32 @@ class SolveQuizTestView(TestCase):
         self.assertEqual("문제 시작 페이지", soup.title.text)
 
     # 2. 시작하기 버튼 누르면 필적확인란이 같을경우 응시자와 오늘날짜가 session에 들어가는지 확인
+    def test_quiz_start_page_post_same_saying_tester_and_today_in_session_check(self):
+        # Given
+        response = self.client.get(self.quiz_001.get_absolute_url())
+        saying = response.context["saying"]
+
+        data = {
+            "tester-name": self.user.username,
+            "test-date": date.today(),
+            "follow-saying": saying,
+            "saying": saying,
+        }
+
+        # When
+        self.client.post(self.quiz_001.get_absolute_url(), data)
+        session = self.client.session
+        tester_name = session["tester_name"]
+        test_date = session["test_date"]
+
+        # Then
+        """
+        세션에 저장된 응시자 성명 확인
+        세션에 저장된 응시일자가 오늘인지 확인
+        """
+        self.assertEqual(tester_name, data["tester-name"])
+        self.assertEqual(test_date, data["test-date"].strftime("%Y-%m-%d"))
+
     # 3. 시작하기 버튼 누르면 필적확인란이 같을경우 quiz_solve 페이지로 이동 확인
 
     # TODO: 문제풀기 페이지로 이동했을경우 quiz_solve 페이지 확인

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -4,7 +4,6 @@ from django.test import Client, TestCase
 
 from make_quiz.models import QuizExample, QuizQuestion
 from my_quiz.models import Quiz
-from solve_quiz.views import random_saying
 
 
 # Create your tests here.
@@ -76,13 +75,18 @@ class SolveQuizTestView(TestCase):
     def test_quiz_start_random_saying_check(self):
         # Given
         response = self.client.get(self.quiz_001.get_absolute_url())
+        sayings = [
+            "늦었다고 생각할 때가 진짜 너무 늦었다",
+            "내일도 할 수 있는 일을 굳이 오늘 할 필요는 없다",
+            "길이 없으면 길을 찾아라, 찾아도 없으면 길을 닦아나가라",
+        ]
 
         # When
         soup = BeautifulSoup(response.content, "html.parser")
         saying = soup.find("div", id="random_saying")
 
         # Then
-        self.assertIn(saying.text, random_saying())
+        self.assertIn(saying.text, sayings)
 
     # 4. 시작하기 버튼
     #   시작하기 버튼 누르면 성명, 응시일자 저장되는지 확인

--- a/solve_quiz/tests.py
+++ b/solve_quiz/tests.py
@@ -78,21 +78,17 @@ class SolveQuizTestView(TestCase):
         self.assertEqual(self.quiz_001.author.username, quiz_author.text)
 
     # 3. 필적확인란 랜덤 명언 값 존재하는지 확인하기
-    def test_quiz_start_random_saying_check(self):
+    def test_quiz_start_get_random_saying_check(self):
         # Given
         response = self.client.get(self.quiz_001.get_absolute_url())
-        sayings = [
-            "늦었다고 생각할 때가 진짜 너무 늦었다",
-            "내일도 할 수 있는 일을 굳이 오늘 할 필요는 없다",
-            "길이 없으면 길을 찾아라, 찾아도 없으면 길을 닦아나가라",
-        ]
 
         # When
         soup = BeautifulSoup(response.content, "html.parser")
-        saying = soup.find("div", id="random_saying")
+        saying = soup.find("div", id="random-saying")
 
         # Then
-        self.assertIn(saying.text, sayings)
+        '''response로 보낸 명언과 html의 명언 일치확인'''
+        self.assertEqual(response.context['saying'], saying.text)
 
     # TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(POST)
     # 1. 시작하기 버튼 누르면 필적확인란 값이 다를경우 재로드 확인

--- a/solve_quiz/urls.py
+++ b/solve_quiz/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("<int:pk>/", views.solve_quiz),
+    path("<int:pk>/", views.start_quiz),
+    path("<int:pk>/solving/", views.solve_quiz),
 ]

--- a/solve_quiz/views.py
+++ b/solve_quiz/views.py
@@ -37,6 +37,15 @@ def solve_quiz(request, pk):
 
         # Todo: 필적확인란이 일치하면 세션 저장 후 quiz페이지
         if follow_saying == saying:
+
+            tester_name = request.POST["tester-name"]
+            test_date = request.POST["test-date"]
+            print(test_date)
+
+            """세션을 이용해 응시자 정보 저장"""
+            request.session["tester_name"] = tester_name
+            request.session["test_date"] = test_date
+
             return render(request, "solve_quiz/quiz.html")
         # Todo:필적확인란 불일치하면 quiz_start 페이지 redirect
         else:

--- a/solve_quiz/views.py
+++ b/solve_quiz/views.py
@@ -1,6 +1,6 @@
 import random
 
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 
 from my_quiz.models import Quiz
 
@@ -10,18 +10,35 @@ def random_saying():
         "늦었다고 생각할 때가 진짜 너무 늦었다",
         "내일도 할 수 있는 일을 굳이 오늘 할 필요는 없다",
         "길이 없으면 길을 찾아라, 찾아도 없으면 길을 닦아나가라",
+        "부지런함을 대신할 지름길은 없다",
+        "관찰만으로도 많은 것을 배울수 있다",
+        "오늘 걷지 않으면 내일은 뛰어야 한다",
+        "날마다 새로우며 깊어지고 넓어진다",
+        "그대만큼 사랑스러운 사람을 본 일이 없다",
     ]
     return random.choice(sayings)
 
 
 # Create your views here.
 def solve_quiz(request, pk):
-    # print(pk)
-    quiz = Quiz.objects.get(id=pk)
-    # print(f"퀴즈의 제목: {quiz.title}")
-    # print(f"퀴즈의 출제자: {quiz.author}")
-    saying = random_saying()
+    if request.method == "GET":  # get일경우
+        quiz = Quiz.objects.get(id=pk)
+        saying = random_saying()
 
-    return render(
-        request, "solve_quiz/quiz_start.html", {"quiz": quiz, "saying": saying}
-    )
+        return render(
+            request, "solve_quiz/quiz_start.html", {"quiz": quiz, "saying": saying}
+        )
+    else:  # post일경우
+        """saying: 제시된 랜덤필적확인란, follow_saying: 받아쓴 필적확인란"""
+        saying = request.POST["saying"]
+        follow_saying = request.POST["follow-saying"]
+        # print(f'제시된 필적확인란:{saying}')
+        # print(f'받아쓴 필적확인란:{follow_saying}')
+
+        # Todo: 필적확인란이 일치하면 세션 저장 후 quiz페이지
+        if follow_saying == saying:
+
+
+        # Todo:필적확인란 불일치하면 quiz_start 페이지 redirect
+        else:
+            return redirect(f"/qui-es/{pk}/")

--- a/solve_quiz/views.py
+++ b/solve_quiz/views.py
@@ -20,7 +20,7 @@ def random_saying():
 
 
 # Create your views here.
-def solve_quiz(request, pk):
+def start_quiz(request, pk):
     if request.method == "GET":  # get일경우
         quiz = Quiz.objects.get(id=pk)
         saying = random_saying()
@@ -46,7 +46,11 @@ def solve_quiz(request, pk):
             request.session["tester_name"] = tester_name
             request.session["test_date"] = test_date
 
-            return render(request, "solve_quiz/quiz.html")
+            return redirect(f"/qui-es/{pk}/solving/")
         # Todo:필적확인란 불일치하면 quiz_start 페이지 redirect
         else:
             return redirect(f"/qui-es/{pk}/")
+
+
+def solve_quiz(request, pk):
+    return render(request, "solve_quiz/quiz.html")

--- a/solve_quiz/views.py
+++ b/solve_quiz/views.py
@@ -1,6 +1,17 @@
+import random
+
 from django.shortcuts import render
 
 from my_quiz.models import Quiz
+
+
+def random_saying():
+    sayings = [
+        "늦었다고 생각할 때가 진짜 너무 늦었다",
+        "내일도 할 수 있는 일을 굳이 오늘 할 필요는 없다",
+        "길이 없으면 길을 찾아라, 찾아도 없으면 길을 닦아나가라",
+    ]
+    return random.choice(sayings)
 
 
 # Create your views here.
@@ -9,5 +20,8 @@ def solve_quiz(request, pk):
     quiz = Quiz.objects.get(id=pk)
     # print(f"퀴즈의 제목: {quiz.title}")
     # print(f"퀴즈의 출제자: {quiz.author}")
+    saying = random_saying()
 
-    return render(request, "solve_quiz/quiz_start.html", {"quiz": quiz})
+    return render(
+        request, "solve_quiz/quiz_start.html", {"quiz": quiz, "saying": saying}
+    )

--- a/solve_quiz/views.py
+++ b/solve_quiz/views.py
@@ -37,8 +37,7 @@ def solve_quiz(request, pk):
 
         # Todo: 필적확인란이 일치하면 세션 저장 후 quiz페이지
         if follow_saying == saying:
-
-
+            return render(request, "solve_quiz/quiz.html")
         # Todo:필적확인란 불일치하면 quiz_start 페이지 redirect
         else:
             return redirect(f"/qui-es/{pk}/")


### PR DESCRIPTION
<hr/>

[수정]
- sayings 명언 모음집 😁✍ 수정
- make_quiz.view 일부코드 수정 & 필요없는 주석 제거
- test.py 의 StartQuizTestView 함수명 수정
- StartQuizTestView의 setup 퀴즈하나만 생성하도록 수정
- test_enter_quiz_start_page 수정
- test_quiz_start_page_get_title_and_user_check 수정

<hr/>

[추가]
- tests.py
   - test 함수명 지정시 " test_퀴즈시작페이지(quiz_start_page)_메서드(get/post)_함수내용 "으로 함
   - 퀴즈 시작페이지 GET  일경우=>TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(GET)
     - [x] test_quiz_start_page_get_random_saying_check 추가
   - 퀴즈 시작페이지 POST 일경우=>TODO: 문제 시작하기 페이지 이동했을경우 quiz_start 페이지 확인(POST)
     - [x] test_quiz_start_page_post_diffrent_saying_check 추가
     - [x] test_quiz_start_page_post_same_saying_tester_and_today_in_session_check 추가
     - [x] test_quiz_start_page_post_same_saying_enter_quiz_page 추가
  
- views.py( solve_quiz 함수 작성 )
    - GET  일경우
      - pk에 맞는 Quiz object 불러오기
      -  필적확인란 랜덤으로 가져오는 함수(random_saying) 이용해 불러오기
      - quiz_start.html 렌더링
    - POST 일경우
      - 필적확인란이 같을경우
        : 세션에 응시자, 응시일자 저장
      - 필적확인란이 다를경우
        : quiz_start.html 리다이렉트